### PR TITLE
remove dep on jakarta.xml.bind

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,13 +306,6 @@
               <configuration>
                 <repoToken>${dangernoodle.coveralls.token}</repoToken>
               </configuration>
-              <dependencies>
-                <dependency>
-                  <groupId>jakarta.xml.bind</groupId>
-                  <artifactId>jakarta.xml.bind-api</artifactId>
-                  <version>${jaxb-api.version}</version>
-                </dependency>
-              </dependencies>
               <executions>
                 <execution>
                   <id>coveralls</id>


### PR DESCRIPTION
From what I know, this new coveralls plugin fixed that dependency; I guess it's something remaining from the old plugin